### PR TITLE
fix: retry 404s three times

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Whatnot-Inc/devxp

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ usage_docs() {
 }
 GITHUB_API_URL="${API_URL:-https://api.github.com}"
 GITHUB_SERVER_URL="${SERVER_URL:-https://github.com}"
+NOT_FOUND_RETRIES=0
 
 validate_args() {
   wait_interval=10 # Waits for 10 seconds
@@ -103,6 +104,10 @@ api() {
     echo >&2 "response: $response"
     if [[ "$response" == *'"Server Error"'* ]]; then 
       echo "Server error - trying again"
+    elif [ $NOT_FOUND_RETRIES -lt 3 ] && [[ "$response" == *'"Not Found"'* ]]; then
+      echo "$response"
+      NOT_FOUND_RETRIES=$((NOT_FOUND_RETRIES + 1))
+      echo >&2 "Not found (attempt $NOT_FOUND_RETRIES) - trying again"
     else
       exit 1
     fi


### PR DESCRIPTION
When this workflow gets a 404 from GitHub, it fails. A deploy will then restart causing a possible merge conflict in the deploy repo.

This will give us two retries if a 404 is received, then fail. If merge conflicts occur again, then we should add a step to CD workflows to check for running deploys workflows before triggering a new one. I didn't add that originally because this is very rare (has only happened twice) and that change would be a bit more complex (given the different ways we call CD pipelines and the info that'd be needed in GitHub API calls).
