### PR TITLE
DT-526 Handle DNS blips, add tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,14 +13,6 @@ on:
       - v**
 
 jobs:
-  unit-test:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Run retry tests
-      run: bash tests/test_retry.sh
-
   build-docker:
     name: Build docker image
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,14 @@ on:
       - v**
 
 jobs:
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run retry tests
+      run: bash tests/test_retry.sh
+
   build-docker:
     name: Build docker image
     runs-on: ubuntu-latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,12 +84,14 @@ validate_args() {
 }
 
 lets_wait() {
-  echo "Sleeping for ${wait_interval} seconds"
-  sleep "$wait_interval"
+  local interval=${1:-$wait_interval}
+  echo >&2 "Sleeping for $interval seconds"
+  sleep "$interval"
 }
 
 api() {
   path=$1; shift
+  local curl_exit_code
   if response=$(curl --fail-with-body -sSL \
       "${GITHUB_API_URL}/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/$path" \
       -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
@@ -99,11 +101,18 @@ api() {
   then
     echo "$response"
   else
+    curl_exit_code=$?
     echo >&2 "api failed:"
     echo >&2 "path: $path"
     echo >&2 "response: $response"
-    if [[ "$response" == *'"Server Error"'* ]]; then 
-      echo "Server error - trying again"
+    # Retry on transient curl errors (DNS, connection, timeout)
+    # 6=DNS, 7=connection refused, 28=timeout, 35=SSL connect, 56=recv error
+    if [[ $curl_exit_code -eq 6 || $curl_exit_code -eq 7 || $curl_exit_code -eq 28 || $curl_exit_code -eq 35 || $curl_exit_code -eq 56 ]]; then
+      echo "{}"
+      echo >&2 "Transient network error (curl exit code $curl_exit_code) - trying again"
+    elif [[ "$response" == *'"Server Error"'* ]]; then
+      echo "{}"
+      echo >&2 "Server error - trying again"
     elif [ $NOT_FOUND_RETRIES -lt 3 ] && [[ "$response" == *'"Not Found"'* ]]; then
       echo "$response"
       NOT_FOUND_RETRIES=$((NOT_FOUND_RETRIES + 1))
@@ -114,11 +123,6 @@ api() {
   fi
 }
 
-lets_wait() {
-  local interval=${1:-$wait_interval}
-  echo >&2 "Sleeping for $interval seconds"
-  sleep "$interval"
-}
 
 # Return the ids of the most recent workflow runs, optionally filtered by user
 get_workflow_runs() {

--- a/tests/test_retry.sh
+++ b/tests/test_retry.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Unit tests for api() retry behavior in entrypoint.sh
+set +e
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Required env vars
+export INPUT_OWNER="test-owner"
+export INPUT_REPO="test-repo"
+export INPUT_GITHUB_TOKEN="fake-token"
+export INPUT_WORKFLOW_FILE_NAME="test.yml"
+export GITHUB_OUTPUT=$(mktemp)
+
+# Source functions without running main
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source <(sed '/^main$/d' "$REPO_ROOT/entrypoint.sh")
+set +e  # Re-disable set -e (entrypoint.sh enables it)
+
+# Use short wait interval for fast tests
+wait_interval=0
+propagate_failure=true
+
+# Helper: set up a mock curl using a file-based call counter (needed because
+# api() invokes curl inside a command substitution / subshell)
+setup_mock_curl() {
+  local fail_count=$1
+  local fail_exit_code=$2
+  local fail_response=$3
+
+  CALL_COUNT_FILE=$(mktemp)
+  echo 0 > "$CALL_COUNT_FILE"
+
+  # Export vars so the function can access them in subshells
+  export CALL_COUNT_FILE FAIL_COUNT="$fail_count" FAIL_EXIT_CODE="$fail_exit_code" FAIL_RESPONSE="$fail_response"
+
+  curl() {
+    local count=$(($(cat "$CALL_COUNT_FILE") + 1))
+    echo $count > "$CALL_COUNT_FILE"
+    if [ $count -le $FAIL_COUNT ]; then
+      if [ -n "$FAIL_RESPONSE" ]; then
+        echo "$FAIL_RESPONSE"
+      fi
+      return "$FAIL_EXIT_CODE"
+    fi
+    echo '{"conclusion": "success", "status": "completed"}'
+    return 0
+  }
+  export -f curl
+}
+
+get_call_count() {
+  cat "$CALL_COUNT_FILE"
+}
+
+cleanup_mock() {
+  rm -f "$CALL_COUNT_FILE"
+  # Reset NOT_FOUND_RETRIES between tests
+  NOT_FOUND_RETRIES=0
+}
+
+assert_result() {
+  local name=$1
+  local expected_exit=$2
+  local expected_calls=$3
+  local actual_exit=$4
+  local actual_calls=$5
+
+  if [ $actual_exit -eq $expected_exit ] && [ $actual_calls -eq $expected_calls ]; then
+    echo "PASS $name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    return 0
+  else
+    echo "FAIL $name: expected exit=$expected_exit calls=$expected_calls, got exit=$actual_exit calls=$actual_calls"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+  fi
+}
+
+# Run wait_for_workflow_to_finish in a subshell so that exit 1 from
+# non-retryable errors doesn't kill the test harness.
+run_test() {
+  local name=$1
+  local expected_exit=$2
+  local expected_calls=$3
+
+  > "$GITHUB_OUTPUT"
+  local output_file=$(mktemp)
+
+  (wait_for_workflow_to_finish "12345") > "$output_file" 2>&1
+  local actual_exit=$?
+  local actual_calls=$(get_call_count)
+  cleanup_mock
+
+  if ! assert_result "$name" "$expected_exit" "$expected_calls" "$actual_exit" "$actual_calls"; then
+    cat "$output_file"
+  fi
+  rm -f "$output_file"
+}
+
+# Transient network errors: fail twice then succeed
+setup_mock_curl 2 6 ""
+run_test "DNS resolution failure (exit 6) retries" 0 3
+
+setup_mock_curl 2 7 ""
+run_test "Connection refused (exit 7) retries" 0 3
+
+setup_mock_curl 2 28 ""
+run_test "Timeout (exit 28) retries" 0 3
+
+setup_mock_curl 2 35 ""
+run_test "SSL connect error (exit 35) retries" 0 3
+
+setup_mock_curl 2 56 ""
+run_test "Recv failure (exit 56) retries" 0 3
+
+# HTTP errors: --fail-with-body makes curl exit 22, response body is available
+setup_mock_curl 2 22 '{"message": "Server Error"}'
+run_test "Server error retries" 0 3
+
+setup_mock_curl 2 22 '{"message": "Not Found"}'
+run_test "Not found retries" 0 3
+
+# Happy path
+setup_mock_curl 0 0 ""
+run_test "Immediate success" 0 1
+
+# Non-retryable errors exit immediately
+setup_mock_curl 100 22 '{"message": "Bad credentials"}'
+run_test "Non-retryable error (403) exits" 1 1
+
+# Cleanup
+rm -f "$GITHUB_OUTPUT"
+
+# Summary
+echo "=== Results: $TESTS_PASSED passed, $TESTS_FAILED failed ==="
+[ $TESTS_FAILED -eq 0 ]


### PR DESCRIPTION
## Background
We've been seeing cd workflows fail because of DNS resolution errors
```
curl: (6) Could not resolve host: api.github.com
```

Following up on the root cause, but also we should handle these by retrying.

## Changes
* Retry on transient curl failures
* AFAICT the retry mechanism here was broken on the server error call, so this fixes that as well
* Adds some unit tests to stop future retry regression.
* Remove duplicate `lets_wait` function definition

