### PR TITLE
Retry or fail on dispatch failure

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -122,49 +122,51 @@ api() {
   fi
 }
 
-# Dispatch the workflow, retrying on server (5xx) errors. Unlike api(), a failed
-# dispatch means no run was created, so we must never fall back to polling on
-# error - we retry a bounded number of times and then abort the whole action.
-# Prints nothing on success; returns non-zero if all attempts fail.
+# Perform a single workflow_dispatch POST and classify the outcome. Because
+# workflow_dispatch is NOT idempotent, we must never blindly re-dispatch on
+# error: a 5xx (or network error) can occur AFTER the run was created, so a
+# retry would start a second run. Callers use the classification to decide
+# whether to poll for a run that may have been created despite the error.
+#
+# Sets two globals (rather than using command substitution, so the outcome
+# survives in the caller's shell):
+#   DISPATCH_RESPONSE - the response body (empty on the usual HTTP 204 success)
+#   DISPATCH_OUTCOME  - exactly one classification token:
+#     success   - dispatch accepted (HTTP 204 or a workflow_run_id returned)
+#     ambiguous - 5xx server error or network error; outcome unknown, may have
+#                 created a run
+#     fatal     - non-retryable client error (bad ref, auth, missing workflow);
+#                 no run was created
+DISPATCH_OUTCOME=
+DISPATCH_RESPONSE=
 dispatch_workflow() {
-  local attempt=1
-  local max_attempts=3
-  local result
-
-  while [ "$attempt" -le "$max_attempts" ]
-  do
-    if result=$(gh api \
-      "repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches" \
-      -H 'Accept: application/vnd.github.v3+json' \
-      --method POST \
-      --input - <<EOF 2>&1
+  if DISPATCH_RESPONSE=$(gh api \
+    "repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches" \
+    -H 'Accept: application/vnd.github.v3+json' \
+    --method POST \
+    --input - <<EOF 2>&1
 {"ref":"${ref}","inputs":${client_payload}}
 EOF
-    )
-    then
-      # A successful workflow_dispatch returns HTTP 204 with an empty body.
-      echo "$result"
-      return 0
-    fi
+  )
+  then
+    # A successful workflow_dispatch returns HTTP 204 with an empty body.
+    DISPATCH_OUTCOME=success
+    return 0
+  fi
 
-    echo >&2 "dispatch failed (attempt ${attempt}/${max_attempts}):"
-    echo >&2 "response: $result"
+  echo >&2 "dispatch failed:"
+  echo >&2 "response: $DISPATCH_RESPONSE"
 
-    # Retry only on server/5xx errors (e.g. "Failed to run workflow dispatch"
-    # with HTTP 500). Client errors (bad ref, auth, missing workflow) are fatal.
-    if echo "$result" | grep -qiE "Server Error|HTTP 5[0-9][0-9]|\"status\": ?\"5[0-9][0-9]\""; then
-      if [ "$attempt" -lt "$max_attempts" ]; then
-        echo >&2 "Server error dispatching workflow - trying again"
-        lets_wait
-      fi
-      attempt=$((attempt + 1))
-    else
-      echo >&2 "Non-retryable error dispatching workflow - aborting"
-      return 1
-    fi
-  done
-
-  echo >&2 "Failed to dispatch workflow after ${max_attempts} attempts - aborting"
+  # Ambiguous outcomes (may have created a run despite the error):
+  #  - Server/5xx errors (e.g. "Failed to run workflow dispatch", HTTP 500)
+  #  - Network errors where gh never received a response (DNS/connection/timeout)
+  if echo "$DISPATCH_RESPONSE" | grep -qiE "Server Error|HTTP 5[0-9][0-9]|\"status\": ?\"5[0-9][0-9]\"|error connecting to|connection refused|connection timed out|operation timed out|context deadline exceeded|i/o timeout|TLS handshake timeout|connection reset by peer|broken pipe"; then
+    echo >&2 "Ambiguous dispatch error - outcome unknown, will poll for a run"
+    DISPATCH_OUTCOME=ambiguous
+  else
+    echo >&2 "Non-retryable error dispatching workflow"
+    DISPATCH_OUTCOME=fatal
+  fi
   return 1
 }
 
@@ -182,46 +184,95 @@ get_workflow_runs() {
   sort # Sort to ensure repeatable order, and lexicographically for compatibility with join
 }
 
+# Poll for run ids created since the dispatch (i.e. not in OLD_RUNS), for up to
+# `attempts` intervals. Sets RUN_IDS and returns 0 as soon as any new run is
+# found; returns 1 if none appear within the window.
+poll_for_new_run() {
+  local attempts=$1
+  local new_runs found
+  local i=0
+  while [ "$i" -lt "$attempts" ]
+  do
+    lets_wait
+    new_runs=$(get_workflow_runs "$SINCE")
+    found=$(join -v2 <(echo "$OLD_RUNS") <(echo "$new_runs"))
+    if [ -n "$found" ]; then
+      RUN_IDS="$found"
+      return 0
+    fi
+    i=$((i + 1))
+  done
+  return 1
+}
+
 # Trigger the workflow and set the global RUN_IDS to the ids of the run(s) to
 # wait for. Runs as a plain statement (not inside $(...)) so that a failed
 # dispatch can abort the whole action via exit 1.
+#
+# workflow_dispatch is not idempotent, so on an ambiguous error (5xx/network) we
+# never blindly re-dispatch: we first poll to see whether a run was created
+# despite the error, and only re-dispatch (at most once) if none appeared.
 trigger_workflow() {
   START_TIME=$(date +%s)
   SINCE=$(date -u -Iseconds -d "@$((START_TIME - 120))") # Two minutes ago, to overcome clock skew
 
   OLD_RUNS=$(get_workflow_runs "$SINCE")
 
-  echo >&2 "Triggering workflow:"
-  echo >&2 "  workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches"
-  echo >&2 "  {\"ref\":\"${ref}\",\"inputs\":${client_payload}}"
-
-  if ! dispatch_response=$(dispatch_workflow); then
-    echo >&2 "Error: failed to dispatch workflow; no run was created."
-    exit 1
-  fi
-
-  # Check if the response contains workflow_run_id (new GitHub API behavior)
-  workflow_run_id=$(echo "$dispatch_response" | jq -r '.workflow_run_id // empty' 2>/dev/null)
-
-  if [ -n "$workflow_run_id" ]; then
-    echo >&2 "Workflow run ID returned directly: $workflow_run_id"
-    RUN_IDS="$workflow_run_id"
-    return
-  fi
-
-  # Dispatch succeeded (HTTP 204, empty body) but did not return a run id, so
-  # fall back to polling for the newly created run. This is only reached on a
-  # successful dispatch - errored dispatches abort above.
-  echo >&2 "No workflow_run_id in response, falling back to polling"
-  NEW_RUNS=$OLD_RUNS
-  while [ "$NEW_RUNS" = "$OLD_RUNS" ]
+  local redispatched=false
+  while true
   do
-    lets_wait
-    NEW_RUNS=$(get_workflow_runs "$SINCE")
-  done
+    echo >&2 "Triggering workflow:"
+    echo >&2 "  workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches"
+    echo >&2 "  {\"ref\":\"${ref}\",\"inputs\":${client_payload}}"
 
-  # New run ids
-  RUN_IDS=$(join -v2 <(echo "$OLD_RUNS") <(echo "$NEW_RUNS"))
+    dispatch_workflow || true
+
+    case "$DISPATCH_OUTCOME" in
+      success)
+        # A workflow_run_id may be returned directly (newer GitHub behavior).
+        workflow_run_id=$(echo "$DISPATCH_RESPONSE" | jq -r '.workflow_run_id // empty' 2>/dev/null)
+        if [ -n "$workflow_run_id" ]; then
+          echo >&2 "Workflow run ID returned directly: $workflow_run_id"
+          RUN_IDS="$workflow_run_id"
+          return
+        fi
+        # HTTP 204 with empty body: the dispatch was accepted, so poll
+        # indefinitely for the newly created run (never re-dispatch).
+        echo >&2 "No workflow_run_id in response, polling for the new run"
+        local new_runs
+        RUN_IDS=
+        while [ -z "$RUN_IDS" ]
+        do
+          lets_wait
+          new_runs=$(get_workflow_runs "$SINCE")
+          RUN_IDS=$(join -v2 <(echo "$OLD_RUNS") <(echo "$new_runs"))
+        done
+        return
+        ;;
+
+      ambiguous)
+        # The dispatch may or may not have created a run. Poll a bounded window
+        # before deciding whether to re-dispatch, to avoid double-dispatching.
+        echo >&2 "Polling for a run that may have been created despite the error"
+        if poll_for_new_run 3; then
+          echo >&2 "A run appeared despite the dispatch error; waiting on it"
+          return
+        fi
+        if [ "$redispatched" = true ]; then
+          echo >&2 "Error: no run appeared and dispatch was already retried once; aborting."
+          exit 1
+        fi
+        echo >&2 "No run appeared; re-dispatching once"
+        redispatched=true
+        continue
+        ;;
+
+      *)
+        echo >&2 "Error: failed to dispatch workflow; no run was created."
+        exit 1
+        ;;
+    esac
+  done
 }
 
 comment_downstream_link() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ usage_docs() {
 }
 GITHUB_SERVER_URL="${SERVER_URL:-https://github.com}"
 NOT_FOUND_RETRIES=0
+RUN_IDS=
 
 validate_args() {
   wait_interval=10 # Waits for 10 seconds
@@ -121,6 +122,52 @@ api() {
   fi
 }
 
+# Dispatch the workflow, retrying on server (5xx) errors. Unlike api(), a failed
+# dispatch means no run was created, so we must never fall back to polling on
+# error - we retry a bounded number of times and then abort the whole action.
+# Prints nothing on success; returns non-zero if all attempts fail.
+dispatch_workflow() {
+  local attempt=1
+  local max_attempts=3
+  local result
+
+  while [ "$attempt" -le "$max_attempts" ]
+  do
+    if result=$(gh api \
+      "repos/${INPUT_OWNER}/${INPUT_REPO}/actions/workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches" \
+      -H 'Accept: application/vnd.github.v3+json' \
+      --method POST \
+      --input - <<EOF 2>&1
+{"ref":"${ref}","inputs":${client_payload}}
+EOF
+    )
+    then
+      # A successful workflow_dispatch returns HTTP 204 with an empty body.
+      echo "$result"
+      return 0
+    fi
+
+    echo >&2 "dispatch failed (attempt ${attempt}/${max_attempts}):"
+    echo >&2 "response: $result"
+
+    # Retry only on server/5xx errors (e.g. "Failed to run workflow dispatch"
+    # with HTTP 500). Client errors (bad ref, auth, missing workflow) are fatal.
+    if echo "$result" | grep -qiE "Server Error|HTTP 5[0-9][0-9]|\"status\": ?\"5[0-9][0-9]\""; then
+      if [ "$attempt" -lt "$max_attempts" ]; then
+        echo >&2 "Server error dispatching workflow - trying again"
+        lets_wait
+      fi
+      attempt=$((attempt + 1))
+    else
+      echo >&2 "Non-retryable error dispatching workflow - aborting"
+      return 1
+    fi
+  done
+
+  echo >&2 "Failed to dispatch workflow after ${max_attempts} attempts - aborting"
+  return 1
+}
+
 
 # Return the ids of the most recent workflow runs, optionally filtered by user
 get_workflow_runs() {
@@ -135,6 +182,9 @@ get_workflow_runs() {
   sort # Sort to ensure repeatable order, and lexicographically for compatibility with join
 }
 
+# Trigger the workflow and set the global RUN_IDS to the ids of the run(s) to
+# wait for. Runs as a plain statement (not inside $(...)) so that a failed
+# dispatch can abort the whole action via exit 1.
 trigger_workflow() {
   START_TIME=$(date +%s)
   SINCE=$(date -u -Iseconds -d "@$((START_TIME - 120))") # Two minutes ago, to overcome clock skew
@@ -145,23 +195,23 @@ trigger_workflow() {
   echo >&2 "  workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches"
   echo >&2 "  {\"ref\":\"${ref}\",\"inputs\":${client_payload}}"
 
-  dispatch_response=$(api "workflows/${INPUT_WORKFLOW_FILE_NAME}/dispatches" \
-    --method POST \
-    --input - <<EOF
-{"ref":"${ref}","inputs":${client_payload}}
-EOF
-  )
+  if ! dispatch_response=$(dispatch_workflow); then
+    echo >&2 "Error: failed to dispatch workflow; no run was created."
+    exit 1
+  fi
 
   # Check if the response contains workflow_run_id (new GitHub API behavior)
-  workflow_run_id=$(echo "$dispatch_response" | jq -r '.workflow_run_id // empty')
+  workflow_run_id=$(echo "$dispatch_response" | jq -r '.workflow_run_id // empty' 2>/dev/null)
 
   if [ -n "$workflow_run_id" ]; then
     echo >&2 "Workflow run ID returned directly: $workflow_run_id"
-    echo "$workflow_run_id"
+    RUN_IDS="$workflow_run_id"
     return
   fi
 
-  # Fall back to polling approach (old behavior)
+  # Dispatch succeeded (HTTP 204, empty body) but did not return a run id, so
+  # fall back to polling for the newly created run. This is only reached on a
+  # successful dispatch - errored dispatches abort above.
   echo >&2 "No workflow_run_id in response, falling back to polling"
   NEW_RUNS=$OLD_RUNS
   while [ "$NEW_RUNS" = "$OLD_RUNS" ]
@@ -170,8 +220,8 @@ EOF
     NEW_RUNS=$(get_workflow_runs "$SINCE")
   done
 
-  # Return new run ids
-  join -v2 <(echo "$OLD_RUNS") <(echo "$NEW_RUNS")
+  # New run ids
+  RUN_IDS=$(join -v2 <(echo "$OLD_RUNS") <(echo "$NEW_RUNS"))
 }
 
 comment_downstream_link() {
@@ -233,14 +283,14 @@ main() {
 
   if [ "${trigger_workflow}" = true ]
   then
-    run_ids=$(trigger_workflow)
+    trigger_workflow
   else
     echo "Skipping triggering the workflow."
   fi
 
   if [ "${wait_workflow}" = true ]
   then
-    for run_id in $run_ids
+    for run_id in $RUN_IDS
     do
       wait_for_workflow_to_finish "$run_id"
     done

--- a/tests/test_retry.sh
+++ b/tests/test_retry.sh
@@ -106,23 +106,119 @@ run_wait_test() {
   rm -f "$output_file"
 }
 
-# Run dispatch_workflow in a subshell and assert on exit status + call count.
+# Run dispatch_workflow and assert on its classification (DISPATCH_OUTCOME).
+# dispatch_workflow makes exactly one gh call, so we assert calls=1 always.
 run_dispatch_test() {
   local name=$1
-  local expected_exit=$2
-  local expected_calls=$3
+  local expected_outcome=$2
 
   local output_file=$(mktemp)
-
-  (dispatch_workflow) > "$output_file" 2>&1
-  local actual_exit=$?
+  DISPATCH_OUTCOME=
+  dispatch_workflow > "$output_file" 2>&1
+  local actual_outcome=$DISPATCH_OUTCOME
   local actual_calls=$(get_call_count)
   cleanup_mock
 
-  if ! assert_result "$name" "$expected_exit" "$expected_calls" "$actual_exit" "$actual_calls"; then
+  if [ "$actual_outcome" = "$expected_outcome" ] && [ "$actual_calls" -eq 1 ]; then
+    echo "PASS $name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "FAIL $name: expected outcome=$expected_outcome calls=1, got outcome=$actual_outcome calls=$actual_calls"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
     cat "$output_file"
   fi
   rm -f "$output_file"
+}
+
+# --- Mock for trigger_workflow orchestration tests ---
+# Distinguishes dispatch POSTs (path contains "/dispatches") from run-list
+# queries (path contains "/runs?"). Driven by env:
+#   DISPATCH_SCRIPT : space-separated outcomes per dispatch attempt, each one of
+#                     ok|500|net|422 (ok = HTTP 204 success).
+#   RUNS_APPEAR_ON  : the get_workflow_runs call index (1-based) at/after which a
+#                     NEW run id appears. 0 = never appears.
+# A separate counter tracks run-list calls so RUNS_APPEAR_ON is deterministic.
+setup_mock_orchestration() {
+  export DISPATCH_SCRIPT="$1"
+  export RUNS_APPEAR_ON="$2"
+
+  CALL_COUNT_FILE=$(mktemp)          # dispatch attempts
+  RUNS_CALL_FILE=$(mktemp)           # get_workflow_runs calls
+  echo 0 > "$CALL_COUNT_FILE"
+  echo 0 > "$RUNS_CALL_FILE"
+  export CALL_COUNT_FILE RUNS_CALL_FILE
+
+  # trigger_workflow uses `date +%s` and GNU `date -d` (present in the action's
+  # Alpine image but not on BSD/macOS). Stub both forms so timestamps resolve
+  # regardless of platform.
+  date() {
+    if [ "$1" = "+%s" ]; then echo 1577836800; else echo "2020-01-01T00:00:00+00:00"; fi
+  }
+  export -f date
+
+  gh() {
+    # gh api <path> ...  -> $2 is the repos/.../actions/<path> string
+    local path="$2"
+    if [[ "$path" == *"/dispatches" ]]; then
+      local n=$(($(cat "$CALL_COUNT_FILE") + 1))
+      echo $n > "$CALL_COUNT_FILE"
+      local outcome=$(echo "$DISPATCH_SCRIPT" | cut -d' ' -f"$n")
+      case "$outcome" in
+        ok|"") return 0 ;;  # HTTP 204, empty body
+        500) echo 'gh: Failed to run workflow dispatch (HTTP 500)'; return 1 ;;
+        net) echo 'Post "https://api.github.com/...": dial tcp: connection refused'; return 1 ;;
+        422) echo 'gh: Reference does not exist (HTTP 422)'; return 1 ;;
+      esac
+      return 1
+    fi
+    # Otherwise it's a runs list query.
+    local r=$(($(cat "$RUNS_CALL_FILE") + 1))
+    echo $r > "$RUNS_CALL_FILE"
+    if [ "$RUNS_APPEAR_ON" -ne 0 ] && [ "$r" -ge "$RUNS_APPEAR_ON" ]; then
+      echo '{"workflow_runs":[{"id":111},{"id":999}]}'
+    else
+      echo '{"workflow_runs":[{"id":111}]}'
+    fi
+    return 0
+  }
+  export -f gh
+}
+
+cleanup_orchestration() {
+  rm -f "$CALL_COUNT_FILE" "$RUNS_CALL_FILE"
+  RUN_IDS=
+  DISPATCH_OUTCOME=
+  unset -f gh date
+}
+
+# Run trigger_workflow and assert exit status, resulting RUN_IDS, and number of
+# dispatch attempts made.
+run_trigger_test() {
+  local name=$1
+  local expected_exit=$2
+  local expected_run_ids=$3
+  local expected_dispatches=$4
+
+  local output_file=$(mktemp)
+  local run_ids_file=$(mktemp)
+  # Run in a subshell (exit 1 must not kill the harness); capture RUN_IDS via file.
+  ( trigger_workflow; echo "$RUN_IDS" > "$run_ids_file" ) > "$output_file" 2>&1
+  local actual_exit=$?
+  local actual_run_ids=$(cat "$run_ids_file" 2>/dev/null | tr -d '[:space:]')
+  local actual_dispatches=$(cat "$CALL_COUNT_FILE")
+  cleanup_orchestration
+
+  if [ "$actual_exit" -eq "$expected_exit" ] && \
+     [ "$actual_run_ids" = "$expected_run_ids" ] && \
+     [ "$actual_dispatches" -eq "$expected_dispatches" ]; then
+    echo "PASS $name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "FAIL $name: expected exit=$expected_exit run_ids=$expected_run_ids dispatches=$expected_dispatches, got exit=$actual_exit run_ids=$actual_run_ids dispatches=$actual_dispatches"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    cat "$output_file"
+  fi
+  rm -f "$output_file" "$run_ids_file"
 }
 
 # --- wait_for_workflow_to_finish: api() retry behavior ---
@@ -153,23 +249,49 @@ run_wait_test "Immediate success" 0 1
 setup_mock_gh 100 1 'gh: Bad credentials (HTTP 401)'
 run_wait_test "Non-retryable error (401) exits" 1 1
 
-# --- dispatch_workflow: dispatch retry/fail behavior ---
+# --- dispatch_workflow: outcome classification ---
 
-# Successful dispatch (HTTP 204, empty body) on first try
+# HTTP 204 (empty body) success
 setup_mock_gh 0 0 "" ""
-run_dispatch_test "Dispatch success (204) does not retry" 0 1
+run_dispatch_test "Dispatch 204 -> success" success
 
-# Server error every time: retries up to max_attempts (3) then fails
-setup_mock_gh 100 1 'gh: Failed to run workflow dispatch (HTTP 500)' ""
-run_dispatch_test "Dispatch 500 retries then fails" 1 3
+# 5xx server error -> ambiguous (may have created a run)
+setup_mock_gh 1 1 'gh: Failed to run workflow dispatch (HTTP 500)' ""
+run_dispatch_test "Dispatch 500 -> ambiguous" ambiguous
 
-# Server error twice then success: proceeds
-setup_mock_gh 2 1 'gh: Failed to run workflow dispatch (HTTP 500)' ""
-run_dispatch_test "Dispatch 500 twice then succeeds" 0 3
+# Network error (no response received) -> ambiguous
+setup_mock_gh 1 1 'Post "https://api.github.com/...": dial tcp: connection refused' ""
+run_dispatch_test "Dispatch network error -> ambiguous" ambiguous
 
-# Non-retryable dispatch error (e.g. bad ref / 422) fails immediately
-setup_mock_gh 100 1 'gh: Reference does not exist (HTTP 422)' ""
-run_dispatch_test "Dispatch non-retryable error fails immediately" 1 1
+# 4xx client error -> fatal (no run created)
+setup_mock_gh 1 1 'gh: Reference does not exist (HTTP 422)' ""
+run_dispatch_test "Dispatch 422 -> fatal" fatal
+
+# --- trigger_workflow: poll-first / re-dispatch-once orchestration ---
+
+# 204 success, new run surfaces on first poll -> wait on it, 1 dispatch.
+# runs call #1 is OLD_RUNS (no new run); the new run appears on poll call #2.
+setup_mock_orchestration "ok" 2
+run_trigger_test "Success then run appears" 0 999 1
+
+# 5xx, but a run was created and appears within the 3-poll window ->
+# wait on it WITHOUT re-dispatching (avoids double-dispatch)
+setup_mock_orchestration "500" 2
+run_trigger_test "Ambiguous but run appeared -> no re-dispatch" 0 999 1
+
+# 5xx, no run appears -> re-dispatch once; second attempt also 5xx with no
+# run -> abort. Runs never appear, so 2 total dispatches then exit 1.
+setup_mock_orchestration "500 500" 0
+run_trigger_test "Ambiguous, no run, re-dispatch once then fail" 1 "" 2
+
+# 5xx with no run, then re-dispatch succeeds (204) and run appears ->
+# wait on it, 2 dispatches
+setup_mock_orchestration "500 ok" 5
+run_trigger_test "Ambiguous then re-dispatch succeeds" 0 999 2
+
+# 4xx fatal -> abort immediately, 1 dispatch, no run
+setup_mock_orchestration "422" 0
+run_trigger_test "Fatal dispatch aborts immediately" 1 "" 1
 
 # Cleanup
 rm -f "$GITHUB_OUTPUT"

--- a/tests/test_retry.sh
+++ b/tests/test_retry.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Unit tests for api() retry behavior in entrypoint.sh
+# Unit tests for api()/dispatch retry behavior in entrypoint.sh
 set +e
 
 TESTS_PASSED=0
@@ -20,21 +20,25 @@ set +e  # Re-disable set -e (entrypoint.sh enables it)
 # Use short wait interval for fast tests
 wait_interval=0
 propagate_failure=true
+ref="main"
+client_payload="{}"
 
-# Helper: set up a mock curl using a file-based call counter (needed because
-# api() invokes curl inside a command substitution / subshell)
-setup_mock_curl() {
+# Helper: set up a mock `gh` using a file-based call counter (needed because
+# api() invokes gh inside a command substitution / subshell). The code under
+# test calls `gh api <path> ...`, so the mock ignores the leading `api` arg.
+setup_mock_gh() {
   local fail_count=$1
   local fail_exit_code=$2
   local fail_response=$3
+  local success_response=${4:-'{"conclusion": "success", "status": "completed"}'}
 
   CALL_COUNT_FILE=$(mktemp)
   echo 0 > "$CALL_COUNT_FILE"
 
-  # Export vars so the function can access them in subshells
-  export CALL_COUNT_FILE FAIL_COUNT="$fail_count" FAIL_EXIT_CODE="$fail_exit_code" FAIL_RESPONSE="$fail_response"
+  export CALL_COUNT_FILE FAIL_COUNT="$fail_count" FAIL_EXIT_CODE="$fail_exit_code" \
+    FAIL_RESPONSE="$fail_response" SUCCESS_RESPONSE="$success_response"
 
-  curl() {
+  gh() {
     local count=$(($(cat "$CALL_COUNT_FILE") + 1))
     echo $count > "$CALL_COUNT_FILE"
     if [ $count -le $FAIL_COUNT ]; then
@@ -43,10 +47,12 @@ setup_mock_curl() {
       fi
       return "$FAIL_EXIT_CODE"
     fi
-    echo '{"conclusion": "success", "status": "completed"}'
+    if [ -n "$SUCCESS_RESPONSE" ]; then
+      echo "$SUCCESS_RESPONSE"
+    fi
     return 0
   }
-  export -f curl
+  export -f gh
 }
 
 get_call_count() {
@@ -55,8 +61,10 @@ get_call_count() {
 
 cleanup_mock() {
   rm -f "$CALL_COUNT_FILE"
-  # Reset NOT_FOUND_RETRIES between tests
+  # Reset state between tests
   NOT_FOUND_RETRIES=0
+  RUN_IDS=
+  unset -f gh
 }
 
 assert_result() {
@@ -79,7 +87,7 @@ assert_result() {
 
 # Run wait_for_workflow_to_finish in a subshell so that exit 1 from
 # non-retryable errors doesn't kill the test harness.
-run_test() {
+run_wait_test() {
   local name=$1
   local expected_exit=$2
   local expected_calls=$3
@@ -98,36 +106,70 @@ run_test() {
   rm -f "$output_file"
 }
 
-# Transient network errors: fail twice then succeed
-setup_mock_curl 2 6 ""
-run_test "DNS resolution failure (exit 6) retries" 0 3
+# Run dispatch_workflow in a subshell and assert on exit status + call count.
+run_dispatch_test() {
+  local name=$1
+  local expected_exit=$2
+  local expected_calls=$3
 
-setup_mock_curl 2 7 ""
-run_test "Connection refused (exit 7) retries" 0 3
+  local output_file=$(mktemp)
 
-setup_mock_curl 2 28 ""
-run_test "Timeout (exit 28) retries" 0 3
+  (dispatch_workflow) > "$output_file" 2>&1
+  local actual_exit=$?
+  local actual_calls=$(get_call_count)
+  cleanup_mock
 
-setup_mock_curl 2 35 ""
-run_test "SSL connect error (exit 35) retries" 0 3
+  if ! assert_result "$name" "$expected_exit" "$expected_calls" "$actual_exit" "$actual_calls"; then
+    cat "$output_file"
+  fi
+  rm -f "$output_file"
+}
 
-setup_mock_curl 2 56 ""
-run_test "Recv failure (exit 56) retries" 0 3
+# --- wait_for_workflow_to_finish: api() retry behavior ---
 
-# HTTP errors: --fail-with-body makes curl exit 22, response body is available
-setup_mock_curl 2 22 '{"message": "Server Error"}'
-run_test "Server error retries" 0 3
+# Transient network errors: fail twice then succeed. api() classifies these by
+# matching gh's textual error output, so the mock emits representative messages.
+setup_mock_gh 2 1 'error connecting to api.github.com'
+run_wait_test "DNS resolution failure retries" 0 3
 
-setup_mock_curl 2 22 '{"message": "Not Found"}'
-run_test "Not found retries" 0 3
+setup_mock_gh 2 1 'Post "https://api.github.com/...": dial tcp: connection refused'
+run_wait_test "Connection refused retries" 0 3
+
+setup_mock_gh 2 1 'Get "https://api.github.com/...": context deadline exceeded'
+run_wait_test "Timeout retries" 0 3
+
+# HTTP errors surfaced by gh
+setup_mock_gh 2 1 'gh: Server Error (HTTP 500)'
+run_wait_test "Server error retries" 0 3
+
+setup_mock_gh 2 1 'gh: Not Found (HTTP 404)'
+run_wait_test "Not found retries" 0 3
 
 # Happy path
-setup_mock_curl 0 0 ""
-run_test "Immediate success" 0 1
+setup_mock_gh 0 0 ""
+run_wait_test "Immediate success" 0 1
 
 # Non-retryable errors exit immediately
-setup_mock_curl 100 22 '{"message": "Bad credentials"}'
-run_test "Non-retryable error (403) exits" 1 1
+setup_mock_gh 100 1 'gh: Bad credentials (HTTP 401)'
+run_wait_test "Non-retryable error (401) exits" 1 1
+
+# --- dispatch_workflow: dispatch retry/fail behavior ---
+
+# Successful dispatch (HTTP 204, empty body) on first try
+setup_mock_gh 0 0 "" ""
+run_dispatch_test "Dispatch success (204) does not retry" 0 1
+
+# Server error every time: retries up to max_attempts (3) then fails
+setup_mock_gh 100 1 'gh: Failed to run workflow dispatch (HTTP 500)' ""
+run_dispatch_test "Dispatch 500 retries then fails" 1 3
+
+# Server error twice then success: proceeds
+setup_mock_gh 2 1 'gh: Failed to run workflow dispatch (HTTP 500)' ""
+run_dispatch_test "Dispatch 500 twice then succeeds" 0 3
+
+# Non-retryable dispatch error (e.g. bad ref / 422) fails immediately
+setup_mock_gh 100 1 'gh: Reference does not exist (HTTP 422)' ""
+run_dispatch_test "Dispatch non-retryable error fails immediately" 1 1
 
 # Cleanup
 rm -f "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Background
Errors when dispatching aren't handled well, leaving doomed workflows polling for results until the step times out.  Example: https://github.com/Whatnot-Inc/whatnot_backend/actions/runs/28871267338/job/85636518486

Going for functional over perfection here, as this workflow will be a lot less important and maybe even unused in a post buildkite world

## Changes
* Detect errors from dispatch response and 
   * If it's a clear failure, immediately fail
   * If it's an ambiguous failure, retry once before failing
* Have claude rework the unit tests to switch from curl to gh mocking. This was changed in the previous PR contributed by blacksmith
* Have claude update unit tests to test for the new expected behaviors

## Testing
* Vibe-coded unit tests which seem plausible
* Tested happy path here: https://github.com/Whatnot-Inc/argo-app-test/actions/runs/28897614072/job/85726325270